### PR TITLE
Removed .htaccess requirements to allow for use on Nginx and other servers

### DIFF
--- a/mumble/_actions.php
+++ b/mumble/_actions.php
@@ -85,7 +85,7 @@
 			$newServer->setSuperuserPassword($pw);
 			
 
-			header('location: '.$MyConfig['http_adress'].'/mumble/server/'.$newServerID.'/overview');
+			header('location: '.$MyConfig['http_adress'].'/mumble/index.php?server_id='.$newServerID.'&display=overview');
 		}	
 		else
 		{

--- a/mumble/_servers.php
+++ b/mumble/_servers.php
@@ -50,7 +50,7 @@ echo '
 			$Server = $Server->ice_context($Password);
 		
 		echo '
-			<div class="server" onclick="window.location.href=\''. $MyConfig['http_adress'] . '/mumble/server/'. $Server->id() .'/overview' .'\';">
+			<div class="server" onclick="window.location.href=\''. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $Server->id() .'&display=overview' .'\';">
 						<span style="font-size: 16px; font-weight: bold; display: block; margin-bottom: 5px; text-align:center;">'. $Server->getConf('registername') .'</span>
 						<center><img src="'.$MyConfig['http_adress'].'/template/images/mumble.png" width="150" height="150"><br><br>';
 						echo ( $Server->isRunning() ? '<span class="label label-success">En-Ligne</span>' : '<span class="label label-danger">Hors-Ligne</span>' ) .'
@@ -72,7 +72,7 @@ echo '
 
 		<div id="new-server" class="dialogbox">
 			<h3 style="text-align: center;">'.$LANGUAGE['newserver_title'].'</h3>
-			<form action="'. $MyConfig['http_adress'] . '/mumble/new-server" method="post" class="center" id="newserver">
+			<form action="'. $MyConfig['http_adress'] . '/mumble/index.php?display=actions&create-server" method="post" class="center" id="newserver">
 
 				<table style="width: 100%">
 					<tr style="margin-top:10px;">

--- a/mumble/_users.php
+++ b/mumble/_users.php
@@ -116,7 +116,7 @@ echo '
 									<td style="text-align: center; width: 40px;"><img src="'. $MyConfig['http_adress'] .'/template/images/user-big.png" width="25" height="25"/></td>
 									<td>'. $userName .'</td>
 									<td>'. ( $Server->getRegistration(intval($userId))[5] == '' ? $LANGUAGE['user_neverconnected'] : $Server->getRegistration(intval($userId))[5]) .'</td>
-									<td><a href="'. $MyConfig['http_adress'] .'/mumble/server/'. $_GET['server_id'] .'/users/'. $userId .'" class="custom-metro cm-small cm-blue2">'. $LANGUAGE['users_btn_edit'] .'</a> <a href="'. $MyConfig['http_adress'] .'/mumble/server/'. $_GET['server_id'] .'/users/delete-'. $userId .'" class="custom-metro cm-small cm-red">'. $LANGUAGE['users_btn_delete'] .'</a></td>
+									<td><a href="'. $MyConfig['http_adress'] .'/mumble/index.php?server_id='. $_GET['server_id'] .'&display=users&edit='. $userId .'" class="custom-metro cm-small cm-blue2">'. $LANGUAGE['users_btn_edit'] .'</a> <a href="'. $MyConfig['http_adress'] .'/mumble/index.php?server_id='. $_GET['server_id'] .'&display=users&delete='. $userId .'" class="custom-metro cm-small cm-red">'. $LANGUAGE['users_btn_delete'] .'</a></td>
 								</tr>';
 							}
 						}

--- a/mumble/index.php
+++ b/mumble/index.php
@@ -124,14 +124,14 @@ echo '
 						<table style="text-align: center; border:0 !important;" border="0" cellpadding="2" cellspacing="2">
 						  <tbody>
 							<tr>
-							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/start" class="custom-metro cm-green"><i class="fa fa-play-circle"></i> '. $LANGUAGE['action_start'] .'</a></td>
-							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/restart" class="custom-metro cm-blue"><i class="fa fa-repeat"></i> '. $LANGUAGE['action_restart'] .'</a></td>
-							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/stop" class="custom-metro cm-red"><i class="fa fa-square"></i> '. $LANGUAGE['action_stop'] .'</a></td>
+							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $_GET['server_id'] .'&display=actions&start" class="custom-metro cm-green"><i class="fa fa-play-circle"></i> '. $LANGUAGE['action_start'] .'</a></td>
+							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $_GET['server_id'] .'&display=actions&restart" class="custom-metro cm-blue"><i class="fa fa-repeat"></i> '. $LANGUAGE['action_restart'] .'</a></td>
+							  <td style="width:33%"><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'&display=actions&stop" class="custom-metro cm-red"><i class="fa fa-square"></i> '. $LANGUAGE['action_stop'] .'</a></td>
 							</tr>
 							<tr>
-							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/config" class="custom-metro cm-brown"><i class="fa fa-file-text"></i> '. $LANGUAGE['action_config'] .'</a></td>
-							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/users" class="custom-metro cm-brown"><i class="fa fa-users"></i> '. $LANGUAGE['action_users'] .'</a></td>
-							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/server/'. $_GET['server_id'] .'/viewer" class="custom-metro cm-brown"><i class="fa fa-eye"></i> '. $LANGUAGE['action_viewer'] .'</a></td>
+							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $_GET['server_id'] .'&display=config" class="custom-metro cm-brown"><i class="fa fa-file-text"></i> '. $LANGUAGE['action_config'] .'</a></td>
+							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $_GET['server_id'] .'&display=users" class="custom-metro cm-brown"><i class="fa fa-users"></i> '. $LANGUAGE['action_users'] .'</a></td>
+							  <td><a href="'. $MyConfig['http_adress'] . '/mumble/index.php?server_id='. $_GET['server_id'] .'&display=viewer" class="custom-metro cm-brown"><i class="fa fa-eye"></i> '. $LANGUAGE['action_viewer'] .'</a></td>
 							</tr>
 						  </tbody>
 						</table>
@@ -161,7 +161,7 @@ echo '
 			<h3 class="center">'. $LANGUAGE['overview_delete_title'] .'</h3>
 			<p style="text-align: center;"></p>
 
-				<form action="'. $MyConfig['http_adress'] . '/mumble/delete-server" method="post" class="center" id="deleteserver">
+				<form action="'. $MyConfig['http_adress'] . '/mumble/index.php?display=actions&delete-server" method="post" class="center" id="deleteserver">
 					<input type="hidden" name="server_id" value="'.$Server->id().'">
 					<div style="width: 500px; text-align:center;"><a href="#" onclick="deleteserver.submit();" class="custom-metro cm-green cm-auto">'. $LANGUAGE['overview_delete_btn_yes'] .'</a> <a href="#" onclick="$(\'#delete-server\').dialog(\'close\'); return false;"class="custom-metro cm-red cm-auto">'. $LANGUAGE['overview_delete_btn_no'] .'</a></div>
 				</form>


### PR DESCRIPTION
URLs do not need to look pretty for a private panel. Removing this requirement ensures that the software works on Nginx and other HTTP servers as well as Apache.